### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-#Meteor Best Practices
+# Meteor Best Practices
 
 This project was created to act as starting point for your projects and to combine all of current best practices for Meteor.js.
 
-##Stack:
+## Stack:
 - Meteor 1.2 - https://www.meteor.com
     + details about the release - http://info.meteor.com/blog/announcing-meteor-1.2
 - React - http://facebook.github.io/react
@@ -10,21 +10,21 @@ This project was created to act as starting point for your projects and to combi
 - MongoDB - https://www.mongodb.org
 - Materialize CSS (Google Material UI) - http://materializecss.com
 
-##Goals:
+## Goals:
 - Use "packages for everything" to make the application modular-first
 - Build small, very specific custom packages that do one thing very well
 - Split up files into their purposes; ie: client only code goes in client.js
 - Security. Security. Security. (Security)
 - Test the "important" things.
 
-##Demo: http://best-practices.meteor.com/
+## Demo: http://best-practices.meteor.com/
 
-##Coding Guidelines:
+## Coding Guidelines:
 - Every file must have a blank line at the end. (http://unix.stackexchange.com/questions/18743/whats-the-point-in-adding-a-new-line-to-the-end-of-a-file)
 - .gitignore extra files such as RubyMine (or any other IDE) project files to keep them out of the project
 - ...
 
-##Questions:
+## Questions:
 - Q: Why "packages for everything"?
   A: 
     1) No need to use Meteor.isClient or Meteor.isServer unless the code is common between the client and server. The package.js definition file tells meteor which files should be run.

--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -2,7 +2,7 @@
 
 This package is the entry point for the application. It is included in the main .meteor/packages file and is the only package listed.
 
-##Included Packages:
+## Included Packages:
 - accounts-password
 - templating
 - less


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
